### PR TITLE
Add release GitHub action

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish release
+
+on:
+  push:
+    tags:
+    - v*
+
+jobs:
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+
+    - name: Install Python modules
+      run: pip install -r .github/workflows/requirements.txt
+
+    - name: Create release
+      shell: python
+      run: |
+        import re
+        import requests
+        import subprocess
+
+        # Get the context and secret data that we will need:
+        repository = "${{ github.repository }}"
+        reference = "${{ github.ref }}"
+        token = "${{ secrets.GITHUB_TOKEN }}"
+
+        # Calculate the version number:
+        version = re.sub(r"^refs/tags/v(.*)$", r"\1", reference)
+
+        # Build and push the image:
+        try:
+            subprocess.run(
+                args=[
+                    "podman", "login",
+                    "--username", "${{ secrets.QUAY_USER }}",
+                    "--password", "${{ secrets.QUAY_TOKEN }}",
+                    "quay.io",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                args=[
+                    "make",
+                    f"version={version}",
+                    "image",
+                    "push",
+                ],
+                check=True,
+            )
+        finally:
+            subprocess.run(
+                args=[
+                    "podman", "logout",
+                    "quay.io",
+                ],
+                check=True,
+            )
+
+        # Get the list of changes:
+        body = ""
+        with open("CHANGES.md", "r") as stream:
+            while True:
+                line = stream.readline()
+                if line == "" or line.startswith("## " + version):
+                    break
+            while True:
+                line = stream.readline()
+                if line == "" or line.startswith("## "):
+                    break
+                body += line
+
+        # Send the request to create the release:
+        response = requests.post(
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            json={
+                "tag_name": f"v{version}",
+                "name": f"Release {version}",
+                "body": body,
+            },
+            url=(
+                "https://api.github.com"
+                f"/repos/{repository}/releases"
+            ),
+        )
+        response.raise_for_status()

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 
-# Details of the image:
-version:=latest
-tag:=quay.io/openshift-online/ocm-kafka:$(version)
+# This file lists the Python dependencies used by the GitHub actions.
 
-.PHONY: image
-image:
-	podman build --tag "$(tag)" .
-
-.PHONY: push
-push:
-	podman push "$(tag)"
+requests


### PR DESCRIPTION
This patch adds a GitHub action that publishes the image to _quay.io_
and creates a release when a new tag is pushed.